### PR TITLE
Remove promise chains and use async/await 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "closure-templates": "^20160825.0.0",
     "fs-extra": "1.0.0",
-    "google-closure-library": "^20180805.0.0"
+    "google-closure-library": "^20180805.0.0",
+    "rimraf": "^2.6.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
@@ -55,7 +56,6 @@
     "lint-staged": "^7.2.2",
     "prettier": "^1.14.2",
     "prettier-package-json": "^2.0.0",
-    "rimraf": "^2.6.2",
     "yarn": "^1.9.4"
   },
   "keywords": [

--- a/src/SoyCompiler.js
+++ b/src/SoyCompiler.js
@@ -674,14 +674,14 @@ export default class SoyCompiler {
    * @return {Promise}
    * @private
    */
-  _postCompileProcess(outputDir, files, vmType) {
+  async _postCompileProcess(outputDir, files, vmType) {
     const options = this._options;
     vmType = vmType || DEFAULT_VM_CONTEXT;
 
     // Build a list of paths that we expect as output of the soy compiler.
-    const templatePaths = files.map(function(file) {
-      return this._getOutputFile(outputDir, file, vmType);
-    }, this);
+    const templatePaths = files.map(file =>
+      this._getOutputFile(outputDir, file, vmType)
+    );
 
     try {
       if (options.concatOutput)
@@ -694,6 +694,6 @@ export default class SoyCompiler {
       // Load the compiled templates into memory.
       return this.loadCompiledTemplateFiles(templatePaths, { vmType });
     }
-    return Promise.resolve(true);
+    return true;
   }
 }

--- a/src/SoyCompiler.js
+++ b/src/SoyCompiler.js
@@ -405,34 +405,25 @@ export default class SoyCompiler {
    * @param {EventEmitter} emitter
    * @private
    */
-  _compileTemplatesAndEmit(inputDir, emitter) {
-    findFiles(inputDir, 'soy')
-      .then(files => {
-        if (files.length === 0) return emitCompile(emitter);
+  async _compileTemplatesAndEmit(inputDir, emitter) {
+    let files;
+    try {
+      files = await findFiles(inputDir, 'soy');
+    } catch (err) {
+      return emitCompile(emitter, err);
+    }
 
-        const outputDir = this._createOutputDir();
-        return this._maybeUsePrecompiledFiles(outputDir, files)
-          .then(dirtyFiles => {
-            this._maybeSetupDynamicRecompile(
-              inputDir,
-              outputDir,
-              files,
-              emitter
-            );
-            return this._compileTemplateFilesAndEmit(
-              inputDir,
-              outputDir,
-              files,
-              dirtyFiles,
-              emitter
-            );
-          })
-
-          .catch(error => {
-            throw error;
-          });
-      })
-      .catch(err => emitCompile(emitter, err));
+    if (files.length === 0) return emitCompile(emitter);
+    const outputDir = this._createOutputDir();
+    const dirtyFiles = await this._maybeUsePrecompiledFiles(outputDir, files);
+    this._maybeSetupDynamicRecompile(inputDir, outputDir, files, emitter);
+    return this._compileTemplateFilesAndEmit(
+      inputDir,
+      outputDir,
+      files,
+      dirtyFiles,
+      emitter
+    );
   }
 
   /**

--- a/src/SoyCompiler.js
+++ b/src/SoyCompiler.js
@@ -245,22 +245,25 @@ export default class SoyCompiler {
    * @return {Promise}
    * @private
    */
-  _compileTemplateFilesAndEmit(
+  async _compileTemplateFilesAndEmit(
     inputDir,
     outputDir,
     allFiles,
     dirtyFiles,
     emitter
   ) {
-    return this._compileTemplateFilesAsync(
-      inputDir,
-      outputDir,
-      allFiles,
-      dirtyFiles
-    ).then(
-      () => this._finalizeCompileTemplates(outputDir, emitter),
-      err => emitCompile(emitter, err)
-    );
+    try {
+      await this._compileTemplateFilesAsync(
+        inputDir,
+        outputDir,
+        allFiles,
+        dirtyFiles
+      );
+    } catch (err) {
+      return emitCompile(emitter, err);
+    }
+
+    return this._finalizeCompileTemplates(outputDir, emitter);
   }
 
   /**

--- a/src/SoyCompiler.js
+++ b/src/SoyCompiler.js
@@ -196,10 +196,8 @@ export default class SoyCompiler {
   }
 
   /**
-   * Compiles all soy files within the provided array and loads them into memory.  The callback
-   * will be called when templates are ready, or an error occurred along the way.
+   * Compiles all soy files within the provided array and loads them into memory.
    * @param {Array.<string>} files
-   * @param {function (Error, boolean)=} callback
    * @return {EventEmitter} An EventEmitter that publishes a "compile" event after every compile.
    */
   async compileTemplateFiles(files) {
@@ -449,7 +447,6 @@ export default class SoyCompiler {
    * Loads precompiled templates into memory.  All .soy.js files within the provided inputDir will be
    * loaded.
    * @param {string} inputDir
-   * @param {function (Error, boolean)}
    */
   async loadCompiledTemplates(inputDir) {
     const files = await findFiles(inputDir, 'soy.js');
@@ -460,8 +457,7 @@ export default class SoyCompiler {
   /**
    * Loads an array of template files into memory.
    * @param {Array.<string>} files
-   * @param {function (Error, boolean) | Object} callbackOrOptions
-   * @param {function (Error, boolean)=} callback
+   * @param {Object} options
    */
   async loadCompiledTemplateFiles(files, options) {
     const { vmType } = options;

--- a/src/SoyCompiler.js
+++ b/src/SoyCompiler.js
@@ -475,7 +475,10 @@ export default class SoyCompiler {
       vmType = vmType2;
     }
 
-    this.getSoyVmContext(vmType).loadCompiledTemplateFiles(files, callback);
+    this.getSoyVmContext(vmType)
+      .loadCompiledTemplateFiles(files)
+      .then(result => callback(null, result))
+      .catch(err => callback(err));
   }
 
   /**

--- a/src/SoyCompiler.js
+++ b/src/SoyCompiler.js
@@ -33,14 +33,6 @@ function emitCompile(emitter, err) {
   }
 }
 
-/**
- * Callback that will log an error.
- */
-function logErrorOrDone(err) {
-  if (err) console.error('soynode:', err);
-  else console.log('soynode: Done');
-}
-
 async function clean(outputDir) {
   try {
     await promisify(rimraf)(outputDir);
@@ -186,22 +178,14 @@ export default class SoyCompiler {
    * Compiles all soy files within the provided directory and loads them into memory.  The callback
    * will be called when templates are ready, or an error occurred along the way.
    * @param {string} inputDir
-   * @param {function (Error, boolean)=} callback
    * @return {EventEmitter} An EventEmitter that publishes a "compile" event after every compile
    *     This is particularly useful if you have allowDynamicRecompile on, so that your server
    *     can propagate the error appropriately. The "compile" event has two arguments: (error, success).
    */
-  compileTemplates(inputDir, callback) {
-    const options = this._options;
+  async compileTemplates(inputDir) {
     const emitter = new EventEmitter();
-    if (options.allowDynamicRecompile) {
-      emitter.on('compile', logErrorOrDone);
-    }
-    if (callback) {
-      emitter.once('compile', callback);
-    }
     this._compileTemplatesAndEmit(inputDir, emitter);
-    return emitter;
+    await promisify(emitter.once).bind(emitter)('compile');
   }
 
   /**

--- a/src/SoyCompiler.js
+++ b/src/SoyCompiler.js
@@ -451,14 +451,10 @@ export default class SoyCompiler {
    * @param {string} inputDir
    * @param {function (Error, boolean)}
    */
-  loadCompiledTemplates(inputDir, callback) {
-    findFiles(inputDir, 'soy.js', (err, files) => {
-      if (err) return callback(err, false);
-      files = files.map(file => path.join(inputDir, file));
-      return this.loadCompiledTemplateFiles(files)
-        .then(res => callback(null, res))
-        .catch(error => callback(error));
-    });
+  async loadCompiledTemplates(inputDir) {
+    const files = await findFiles(inputDir, 'soy.js');
+    const filesMapping = files.map(file => path.join(inputDir, file));
+    return this.loadCompiledTemplateFiles(filesMapping);
   }
 
   /**

--- a/src/SoyCompiler.js
+++ b/src/SoyCompiler.js
@@ -1,11 +1,12 @@
 // Copyright 2014. A Medium Corporation.
 
 import { EventEmitter } from 'events';
-import childProcess, { exec } from 'child_process';
+import childProcess from 'child_process';
 import closureTemplates from 'closure-templates';
 import fs from 'fs-extra';
 import path from 'path';
 import { promisify } from 'util';
+import rimraf from 'rimraf';
 import SoyVmContext from './SoyVmContext';
 import SoyOptions from './SoyOptions';
 import copy from './copy';
@@ -38,6 +39,14 @@ function emitCompile(emitter, err) {
 function logErrorOrDone(err) {
   if (err) console.error('soynode:', err);
   else console.log('soynode: Done');
+}
+
+async function clean(outputDir) {
+  try {
+    await promisify(rimraf)(outputDir);
+  } catch (err) {
+    console.error('soynode: Error deleting temporary files', err);
+  }
 }
 
 /**
@@ -436,10 +445,7 @@ export default class SoyCompiler {
       this._options.eraseTemporaryFiles &&
       !this._options.allowDynamicRecompile
     ) {
-      exec(`rm -r '${outputDir}'`, {}, err => {
-        // TODO(dan): This is a pretty nasty way to delete the files.  Maybe use rimraf
-        if (err) console.error('soynode: Error deleting temporary files', err);
-      });
+      clean(outputDir);
     }
   }
 

--- a/src/SoyVmContext.js
+++ b/src/SoyVmContext.js
@@ -228,36 +228,35 @@ export default class SoyVmContext {
    */
   loadCompiledTemplateFiles(files, callback) {
     const options = this._options;
-    const self = this;
 
     // load the contextJsPaths into the context before the soy template JS
     const filePromises = pathsToPromises(options.contextJsPaths.concat(files));
     const supportedFilePromises = getSupportFilePromises(options.soyUtilsPath);
 
     let result = Promise.resolve(true);
-    if (self._contextInitialized) {
+    if (this._contextInitialized) {
       result = (async () => {
         vm.runInContext(
           RESET_DELTEMPLATE_REGISTRY_CODE,
-          self.getContext(),
+          this.getContext(),
           'soynode-reset.'
         );
       })();
     } else {
       result = result
-        .then(() => loadFiles(self.getContext(), supportedFilePromises))
+        .then(() => loadFiles(this.getContext(), supportedFilePromises))
         .then(() => {
-          self._contextInitialized = true;
+          this._contextInitialized = true;
           return null;
         });
     }
 
     result
-      .then(() => loadFiles(self.getContext(), filePromises))
+      .then(() => loadFiles(this.getContext(), filePromises))
       .then(
         finalResult => {
           // Blow away the cache when all files have been loaded
-          self._templateCache = {};
+          this._templateCache = {};
           return callback(null, finalResult);
         },
         err => callback(err)

--- a/src/SoyVmContext.js
+++ b/src/SoyVmContext.js
@@ -72,12 +72,13 @@ const CLOSURE_PATHS = [
 );
 
 function pathsToPromises(paths) {
-  return paths.map(pathToPromise =>
-    promisify(fs.readFile)(pathToPromise, 'utf8').then(contents => ({
+  return paths.map(async pathToPromise => {
+    const contents = await promisify(fs.readFile)(pathToPromise, 'utf8');
+    return {
       path: pathToPromise,
       contents,
-    }))
-  );
+    };
+  });
 }
 
 let supportFilePromises = null;

--- a/src/SoyVmContext.js
+++ b/src/SoyVmContext.js
@@ -112,24 +112,26 @@ const RESET_DELTEMPLATE_REGISTRY_CODE =
  * @param {Array.<Promise>} filePromises Promises of {path, contents} tuples
  * @return {Promise.Promise}
  */
-function loadFiles(context, filePromises) {
+async function loadFiles(context, filePromises) {
   let i = 0;
 
-  function next(result) {
+  async function next(result) {
     // Evaluate the template code in the context of the soy VM context.  Any variables defined
     // in the template file will become members of the vmContext object.
     vm.runInContext(result.contents, context, result.path);
 
     if (i >= filePromises.length) {
-      return Promise.resolve(true);
+      return true;
     }
-    return filePromises[i++].then(next);
+    const nextResult = await filePromises[i++];
+    return next(nextResult);
   }
 
   if (!filePromises.length) {
-    return Promise.resolve(true);
+    return true;
   }
-  return filePromises[i++].then(next);
+  const result = await filePromises[i++];
+  return next(result);
 }
 
 /**


### PR DESCRIPTION
- Drop all cases of useless `.bind`
- Remove all callbacks in favor of promises
- Utilize `async`/`await` instead of promise chains.
- Switch from `rm -r` to `rimraf`
- Remove `logErrorOrDone` function
  - Future: Remove all console statements & properly handle errors